### PR TITLE
Fix endpoint URL on POST documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ POST /signup
 ```
 
 ```bash
-curl "https://api-iddog.idwall.co/signup" \
+curl "https://iddog-nrizncxqba-uc.a.run.app/signup" \
 -H "Content-Type: application/json" \
 -d '{ "email": "your@email.com" }'
 ```


### PR DESCRIPTION
This PR fix the endpoint URL to the right one, that wasn't updated on POST documentation.